### PR TITLE
Remove unused vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
 FROM alpine:3.14.0
 
-# 3rd party soft dependency versions
-ARG INFRACOST_VERSION=0.9.13
-ARG TERRAGRUNT_VERSION=0.35.4
-
 RUN apk -U upgrade && apk add --no-cache \
     aws-cli \
     ca-certificates \


### PR DESCRIPTION
We now always install the latest versions of Infracost and Terragrunt.