### PR TITLE
Use alpine 3.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14.0
+FROM alpine:3.15
 
 RUN apk -U upgrade && apk add --no-cache \
     aws-cli \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,12 @@ RUN apk -U upgrade && apk add --no-cache \
     openssh-keygen
 
 # Download infracost
-RUN curl -s -L https://github.com/infracost/infracost/releases/latest/download/infracost-linux-amd64.tar.gz | \
+RUN wget -q -c https://github.com/infracost/infracost/releases/latest/download/infracost-linux-amd64.tar.gz -O - | \
     tar xz -C /tmp && \
     mv /tmp/infracost-linux-amd64 /bin/infracost
 
 # Download Terragrunt.
-RUN wget -O /bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/latest/download/terragrunt_linux_amd64 \
+RUN wget -q -O /bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/latest/download/terragrunt_linux_amd64 \
     && chmod +x /bin/terragrunt
 
 RUN echo "hosts: files dns" > /etc/nsswitch.conf \


### PR DESCRIPTION
## what changed

* Changed `3.14.0` to more generic and up to date `3.15`
* Linted with hadolint so used `wget` for consistency and used `-q` to keep it quiet

## commands

```
✗ docker build -t spacelift-runner .
✗ docker run --tty -it spacelift-runner infracost --version
Infracost v0.9.24
✗ docker run --tty -it spacelift-runner terragrunt --version
terragrunt version v0.37.1
✗ docker run --tty -it spacelift-runner cat /etc/os-release
NAME="Alpine Linux"
ID=alpine
VERSION_ID=3.15.4
PRETTY_NAME="Alpine Linux v3.15"
HOME_URL="https://alpinelinux.org/"
BUG_REPORT_URL="https://bugs.alpinelinux.org/"
```

`hadolint` before

```
✗ hadolint Dockerfile
Dockerfile:3 DL3018 warning: Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`
Dockerfile:18 DL3047 info: Avoid use of wget without progress bar. Use `wget --progress=dot:giga <url>`.Or consider using `-q` or `-nv` (shorthands for `--quiet` or `--no-verbose`).
Dockerfile:18 DL4006 warning: Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check
Dockerfile:23 DL3047 info: Avoid use of wget without progress bar. Use `wget --progress=dot:giga <url>`.Or consider using `-q` or `-nv` (shorthands for `--quiet` or `--no-verbose`).
```

`hadolint` after

```
✗ hadolint Dockerfile
Dockerfile:3 DL3018 warning: Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`
Dockerfile:18 DL4006 warning: Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check
```

## references

* https://hub.docker.com/_/alpine
* https://github.com/hadolint/hadolint