### PR TITLE
Add tzdata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN apk -U upgrade && apk add --no-cache \
     git \
     jq \
     openssh \
-    openssh-keygen
+    openssh-keygen \
+    tzdata
 
 # Download infracost
 RUN curl -s -L https://github.com/infracost/infracost/releases/latest/download/infracost-linux-amd64.tar.gz | \


### PR DESCRIPTION
Add the `tzdata` package so that timezone information is available. This is important for the downstream Pulumi images which can require this.