### PR TITLE
Move from aws cli v1 to aws cli v2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,13 @@ jobs:
           username: ${{ secrets.AWS_ACCESS_KEY_ID }}
           password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
+      - name: Log in to GitHub registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
@@ -35,4 +42,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/future' }}
-          tags: ${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:${{ github.ref == 'refs/heads/main' && 'latest' || 'future' }}
+          tags: |
+            ${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:${{ github.ref == 'refs/heads/main' && 'latest' || 'future' }}
+            ghcr.io/spacelift-io/runner-terraform:${{ github.ref == 'refs/heads/main' && 'latest' || 'future' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM alpine:3.14.0
 
 RUN apk -U upgrade && apk add --no-cache \
     aws-cli \
+    bash \
     ca-certificates \
     curl \
     git \


### PR DESCRIPTION
The AWS CLI team still works on building aws cli v2 from the source, see: https://github.com/aws/aws-cli/issues/6785 . Adding the AWS CLI v2 to the package repository might take some time.

The easiest way found by the community is to use [PyInstaller](https://pyinstaller.org/en/stable/), see https://github.com/aws/aws-cli/issues/4685#issuecomment-1094307056.

In this PR, we follow this approach, we use PyInstaller in a builder image to build the AWS CLI v2 and then copy it to the final image.