### PR TITLE
Move from aws cli v1 to aws cli v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-alpine3.14 as aws-cli-builder
+FROM python:3.9-alpine3.16 as aws-cli-builder
 
 ARG TARGETARCH
 
@@ -23,7 +23,7 @@ RUN unzip /aws/dist/awscli-exe.zip && \
     ./aws/install --bin-dir /aws-cli-bin && \
     /aws-cli-bin/aws --version
 
-FROM alpine:3.14.8 as runner
+FROM alpine:3.16 as runner
 
 ARG TARGETARCH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,33 @@
-FROM alpine:3.16
+FROM python:3.9-alpine3.14 as aws-cli-builder
+
+ARG TARGETARCH
+
+RUN apk add --no-cache git \
+        unzip \
+        groff \
+        build-base \
+        libffi-dev \
+        cmake
+
+ENV AWS_CLI_VERSION=2.7.25
+
+RUN mkdir /aws && \
+    git clone --single-branch --depth 1 -b ${AWS_CLI_VERSION} https://github.com/aws/aws-cli.git /aws && \
+    cd /aws && \
+    sed -i'' 's/PyInstaller.*/PyInstaller==5.2/g' requirements-build.txt && \
+    python -m venv venv && \
+    . venv/bin/activate && \
+    ./scripts/installers/make-exe
+
+RUN unzip /aws/dist/awscli-exe.zip && \
+    ./aws/install --bin-dir /aws-cli-bin && \
+    /aws-cli-bin/aws --version
+
+FROM alpine:3.14.8 as runner
 
 ARG TARGETARCH
 
 RUN apk -U upgrade && apk add --no-cache \
-    aws-cli \
     bash \
     ca-certificates \
     curl \
@@ -11,7 +35,12 @@ RUN apk -U upgrade && apk add --no-cache \
     jq \
     openssh \
     openssh-keygen \
-    tzdata
+    tzdata \
+    groff # for aws-cli
+
+# AWS CLI
+COPY --from=aws-cli-builder /usr/local/aws-cli/ /usr/local/aws-cli/
+COPY --from=aws-cli-builder /aws-cli-bin/ /usr/local/bin/
 
 # Download infracost
 ADD "https://github.com/infracost/infracost/releases/latest/download/infracost-linux-${TARGETARCH}.tar.gz" /tmp/infracost.tar.gz


### PR DESCRIPTION
The AWS CLI team still works on building aws cli v2 from the source, see: https://github.com/aws/aws-cli/issues/6785 . Adding the AWS CLI v2 to the package repository might take some time.

The easiest way found by the community is to use [PyInstaller](https://pyinstaller.org/en/stable/), see https://github.com/aws/aws-cli/issues/4685#issuecomment-1094307056.

In this PR, we follow this approach, we use PyInstaller in a builder image to build the AWS CLI v2 and then copy it to the final image.