### PR TITLE
Publish ARM images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     ignore-branches:
       - main
       - future
+
 jobs:
   deployment:
     name: Build the image
@@ -12,13 +13,26 @@ jobs:
     container: docker
     steps:
       - name: Check out repository code
-        uses: actions/checkout@master
+        uses: actions/checkout@main
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: linux/arm64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build and push the image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           push: false
-          tags: terraform-runner:latest
+          platforms: linux/amd64,linux/arm64
+          tags: runner-terraform:latest
+
+      # Can't use the output of the previous step because it's
+      # a multiplatform build, so we need to build it again.
+      - name: Test if terragrunt & infracost works
+        run: |
+          docker build --build-arg TARGETARCH=amd64 -t runner-terraform-test .
+          docker run --rm runner-terraform-test sh -c "terragrunt --version && infracost --version"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@master
+        uses: actions/checkout@main
 
       - name: Install the latest AWS CLI
         run: |
@@ -39,19 +39,25 @@ jobs:
         run: aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
 
       - name: Log in to GitHub registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: linux/arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
       - name: Build and push the image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           push: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/future' }}
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:${{ github.ref == 'refs/heads/main' && 'latest' || 'future' }}
             ghcr.io/spacelift-io/runner-terraform:${{ github.ref == 'refs/heads/main' && 'latest' || 'future' }}

--- a/.github/workflows/prod-pr.yml
+++ b/.github/workflows/prod-pr.yml
@@ -8,7 +8,7 @@ jobs:
   create-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@main
 
       - name: Create Pull Request
         uses: vsoch/pull-request-action@1.0.13

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -10,27 +10,36 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
     name: Analyze
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
 
-      - name: Build an image from Dockerfile
+      - name: Set up QEMU
+        if: matrix.arch == 'arm64'
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: linux/arm64
+
+      - name: Build an image from Dockerfile (${{ matrix.arch }} image)
         run: |
-          docker build -t spacelift:${{ github.sha }} .
+          docker build --platform linux/${{ matrix.arch }} --pull --build-arg TARGETARCH=${{ matrix.arch }} -t spacelift:${{ github.sha }}-${{ matrix.arch }} .
 
-      - name: Run Trivy vulnerability scanner
+      - name: Run Trivy vulnerability scanner (${{ matrix.arch }} image)
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: "spacelift:${{ github.sha }}"
+          image-ref: "spacelift:${{ github.sha }}-${{ matrix.arch }}"
           format: "template"
           template: "@/contrib/sarif.tpl"
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH"
 
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v1
+      - name: Upload Trivy scan results to GitHub Security tab (${{ matrix.arch }} image)
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: "trivy-results.sarif"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM alpine:3.14.0
+FROM alpine:3.16
+
+ARG TARGETARCH
 
 RUN apk -U upgrade && apk add --no-cache \
     aws-cli \
@@ -12,13 +14,14 @@ RUN apk -U upgrade && apk add --no-cache \
     tzdata
 
 # Download infracost
-RUN curl -s -L https://github.com/infracost/infracost/releases/latest/download/infracost-linux-amd64.tar.gz | \
-    tar xz -C /tmp && \
-    mv /tmp/infracost-linux-amd64 /bin/infracost
+ADD "https://github.com/infracost/infracost/releases/latest/download/infracost-linux-${TARGETARCH}.tar.gz" /tmp/infracost.tar.gz
+RUN tar -xzf /tmp/infracost.tar.gz -C /bin && \
+    mv "/bin/infracost-linux-${TARGETARCH}" /bin/infracost && \
+    rm /tmp/infracost.tar.gz
 
 # Download Terragrunt.
-RUN wget -O /bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/latest/download/terragrunt_linux_amd64 \
-    && chmod +x /bin/terragrunt
+ADD "https://github.com/gruntwork-io/terragrunt/releases/latest/download/terragrunt_linux_${TARGETARCH}" /bin/terragrunt
+RUN chmod +x /bin/terragrunt
 
 RUN echo "hosts: files dns" > /etc/nsswitch.conf \
     && adduser --disabled-password --uid=1983 spacelift


### PR DESCRIPTION
## Changes

- Bumped all GitHub Action versions
- Bumped `alpine` to the latest version `3.16`
- Multiplatform publishing of the Docker image

## Description
With this change, we'll push the Docker image for two platforms: amd64 and arm64. When downloading the image, if you're on an ARM machine, Docker will automatically pull the ARM. A good example is [`alpine`](https://hub.docker.com/_/alpine/tags):

<img width="1245" alt="image" src="https://user-images.githubusercontent.com/19969687/198835965-c289c4ce-529d-492c-8c7e-933726e567b2.png">

## Trivy vulnerability scan result

Opened PRs for the fixes:
- Infracost: https://github.com/infracost/infracost/pull/2106
- Terragrunt: https://github.com/gruntwork-io/terragrunt/pull/2341