### PR TITLE
Add `shell` mandatory parameter to GH Action

### DIFF
--- a/.github/workflows/publish/action.yml
+++ b/.github/workflows/publish/action.yml
@@ -52,6 +52,7 @@ runs:
           role-duration-seconds: 900
 
       - name: Log in to Amazon public ECR
+        shell: sh
         run: aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
 
       - name: Log in to GitHub registry


### PR DESCRIPTION
Fixing the following error:

<img width="1298" alt="image" src="https://user-images.githubusercontent.com/19969687/203063819-63afc4d6-72d0-4b75-b57d-00f7a3103c92.png">