### PR TITLE
Switch to AWS CLI v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Test if terragrunt & infracost & gcloud are executable (AMD64)
         run: |
           docker build --build-arg TARGETARCH=amd64 --build-arg BASE_IMAGE=${{ matrix.base_image }} -t runner-terraform-test .
-          docker run --rm runner-terraform-test sh -c "terragrunt --version && infracost --version"
+          docker run --rm runner-terraform-test sh -c "terragrunt --version && infracost --version && aws --version"
           if [ ${{ matrix.base_image }} = "gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine" ]; then
             docker run --rm runner-terraform-test sh -c "gcloud --version"
           fi
@@ -51,7 +51,7 @@ jobs:
       - name: Test if terragrunt & infracost & gcloud are executable (ARM64)
         run: |
           docker build --build-arg TARGETARCH=arm64 --build-arg BASE_IMAGE=${{ matrix.base_image }} -t runner-terraform-test .
-          docker run --rm runner-terraform-test sh -c "terragrunt --version && infracost --version"
+          docker run --rm runner-terraform-test sh -c "terragrunt --version && infracost --version && aws --version"
           if [ ${{ matrix.base_image }} = "gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine" ]; then
             docker run --rm runner-terraform-test sh -c "gcloud --version"
           fi

--- a/.github/workflows/publish/action.yml
+++ b/.github/workflows/publish/action.yml
@@ -62,7 +62,7 @@ runs:
           platforms: linux/arm64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build and push the image
         uses: docker/build-push-action@v3

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -44,10 +44,10 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: ${{ env.IMAGE_TAG }}
-          format: "template"
-          template: "@/contrib/sarif.tpl"
+          format: "sarif"
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH"
+          timeout: "10m"
 
       - name: Upload Trivy scan results to GitHub Security tab (${{ matrix.base_image }} ${{ matrix.arch }} image)
         uses: github/codeql-action/upload-sarif@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ FROM ${BASE_IMAGE}
 ARG TARGETARCH
 
 RUN apk -U upgrade && apk add --no-cache \
-    aws-cli \
     bash \
     ca-certificates \
     curl \
@@ -14,6 +13,9 @@ RUN apk -U upgrade && apk add --no-cache \
     openssh \
     openssh-keygen \
     tzdata
+
+COPY --from=ghcr.io/spacelift-io/aws-cli-alpine /usr/local/aws-cli/ /usr/local/aws-cli/
+COPY --from=ghcr.io/spacelift-io/aws-cli-alpine /aws-cli-bin/ /usr/local/bin/
 
 # Download infracost
 ADD "https://github.com/infracost/infracost/releases/latest/download/infracost-linux-${TARGETARCH}.tar.gz" /tmp/infracost.tar.gz

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ The image is pushed to the `public.ecr.aws/spacelift/runner-terraform` public re
 is also pushed to the `ghcr.io/spacelift-io/runner-terraform` as a backup in case of issues
 with ECR.
 
+## Images
+
+We publish two images. One has `gcloud` CLI bundled, the other does not.
+This is because `gcloud` is a very large package and we want to keep the image size down.
+
+- `spacelift-io/runner-terraform:latest` -> no `gcloud` CLI
+- `spacelift-io/runner-terraform:gcp-latest` -> with `gcloud` CLI
+
 ## Branch Model
 
 All changes merged to `main` branch are automatically built and pushed to the Docker repository with the `future` tag.


### PR DESCRIPTION
Since building AWS CLI v2 takes 5 minutes on x64 and 1 hour on arm64, I've separated it to another repository: https://github.com/spacelift-io/aws-cli-alpine