### PR TITLE
Add Python to the base image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Test if terragrunt & infracost & gcloud are executable (AMD64)
         run: |
           docker build --build-arg TARGETARCH=amd64 --build-arg BASE_IMAGE=${{ matrix.base_image }} -t runner-terraform-test .
-          docker run --rm runner-terraform-test sh -c "terragrunt --version && infracost --version && aws --version"
+          docker run --rm runner-terraform-test sh -c "terragrunt --version && infracost --version && aws --version && python --version"
           if [ ${{ matrix.base_image }} = "gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine" ]; then
             docker run --rm runner-terraform-test sh -c "gcloud --version"
           fi
@@ -51,7 +51,7 @@ jobs:
       - name: Test if terragrunt & infracost & gcloud are executable (ARM64)
         run: |
           docker build --build-arg TARGETARCH=arm64 --build-arg BASE_IMAGE=${{ matrix.base_image }} -t runner-terraform-test .
-          docker run --rm runner-terraform-test sh -c "terragrunt --version && infracost --version && aws --version"
+          docker run --rm runner-terraform-test sh -c "terragrunt --version && infracost --version && aws --version && python --version"
           if [ ${{ matrix.base_image }} = "gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine" ]; then
             docker run --rm runner-terraform-test sh -c "gcloud --version"
           fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,10 @@ RUN apk -U upgrade && apk add --no-cache \
     jq \
     openssh \
     openssh-keygen \
+    python3 \
     tzdata
+
+RUN [ -e /usr/bin/python ] || ln -s python3 /usr/bin/python
 
 COPY --from=ghcr.io/spacelift-io/aws-cli-alpine /usr/local/aws-cli/ /usr/local/aws-cli/
 COPY --from=ghcr.io/spacelift-io/aws-cli-alpine /aws-cli-bin/ /usr/local/bin/


### PR DESCRIPTION
When switching from AWS cli v1 to v2, we accidentally removed the Python installation.