### PR TITLE
Don't include AWS cli in Gcloud version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,8 @@ jobs:
   deployment:
     strategy:
       matrix:
-        base_image: ["alpine:3.17", "gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine"]
+        target: [aws, gcp]
+        platform: [linux/amd64, linux/arm64]
     name: Build the image
     runs-on: ubuntu-latest
     container: docker
@@ -23,35 +24,18 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
+        if: matrix.platform == 'linux/arm64'
         with:
           platforms: linux/arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Test if image can be built with buildx
-        uses: docker/build-push-action@v3
+      - name: Bake the ${{ matrix.target }} image 
+        uses: docker/bake-action@v2
         with:
-          push: false
-          build-args: |
-            BASE_IMAGE=${{ matrix.base_image }}
-          platforms: linux/amd64,linux/arm64
-          tags: runner-terraform:latest
-
-      # Can't use the output of the previous step because it's
-      # a multiplatform build, so we need to build it again.
-      - name: Test if terragrunt & infracost & gcloud are executable (AMD64)
-        run: |
-          docker build --build-arg TARGETARCH=amd64 --build-arg BASE_IMAGE=${{ matrix.base_image }} -t runner-terraform-test .
-          docker run --rm runner-terraform-test sh -c "terragrunt --version && infracost --version && aws --version && python --version"
-          if [ ${{ matrix.base_image }} = "gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine" ]; then
-            docker run --rm runner-terraform-test sh -c "gcloud --version"
-          fi
-
-      - name: Test if terragrunt & infracost & gcloud are executable (ARM64)
-        run: |
-          docker build --build-arg TARGETARCH=arm64 --build-arg BASE_IMAGE=${{ matrix.base_image }} -t runner-terraform-test .
-          docker run --rm runner-terraform-test sh -c "terragrunt --version && infracost --version && aws --version && python --version"
-          if [ ${{ matrix.base_image }} = "gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine" ]; then
-            docker run --rm runner-terraform-test sh -c "gcloud --version"
-          fi
+          targets: ${{ matrix.target }}
+          load: true
+          set: |
+            ${{ matrix.target }}.tags=runner-terraform:${{ github.sha }}
+            ${{ matrix.target }}.platform=${{ matrix.platform }}

--- a/.github/workflows/publish/action.yml
+++ b/.github/workflows/publish/action.yml
@@ -2,8 +2,8 @@ name: Publish
 description: Builds and pushes the Docker image to the public ECR and GitHub registry
 
 inputs:
-  base_image:
-    description: Base image to use for the Dockerfile
+  bake_target:
+    description: The target of the bake action
     required: true
   aws_role_to_assume:
     description: The AWS role to assume. Used to authenticate with ECR.
@@ -14,8 +14,8 @@ inputs:
   git_tag:
     description: Git tag to use for the GitHub Release
     required: false
-  image_tags:
-    description: The tags of the Docker image to push
+  bake_set:
+    description: The `set` argument of the bake action
     required: true
   publish_release:
     description: Whether to publish a GitHub Release
@@ -39,7 +39,7 @@ runs:
           pip3 install awscli
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: us-east-1
           role-to-assume: ${{ inputs.aws_role_to_assume }}
@@ -65,14 +65,11 @@ runs:
         uses: docker/setup-buildx-action@v2
 
       - name: Build and push the image
-        uses: docker/build-push-action@v3
+        uses: docker/bake-action@v2
         with:
           push: true
-          context: .
-          build-args: |
-            BASE_IMAGE=${{ inputs.base_image }}
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ inputs.image_tags }}
+          targets: ${{ inputs.bake_target }}
+          set: ${{ inputs.bake_set }}
 
       - name: Create release
         uses: ncipollo/release-action@v1

--- a/.github/workflows/publish_future.yml
+++ b/.github/workflows/publish_future.yml
@@ -26,24 +26,24 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Build and push future image without gcloud
+      - name: Build and push future image (w/ aws cli)
         uses: ./.github/workflows/publish
         with:
-          base_image: 'alpine:3.17'
+          bake_target: aws
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_release: false
-          image_tags: |
-            ${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:future
-            ghcr.io/spacelift-io/runner-terraform:future
+          bake_set: |
+            aws.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:future
+            aws.tags=ghcr.io/spacelift-io/runner-terraform:future
 
-      - name: Build and push future image with gcloud
+      - name: Build and push future image (w/ gcloud cli)
         uses: ./.github/workflows/publish
         with:
-          base_image: 'gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine'
+          bake_target: gcp
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_release: false
-          image_tags: |
-            ${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-future
-            ghcr.io/spacelift-io/runner-terraform:gcp-future
+          bake_set: |
+            gcp.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-future
+            gcp.tags=ghcr.io/spacelift-io/runner-terraform:gcp-future

--- a/.github/workflows/publish_scheduled.yml
+++ b/.github/workflows/publish_scheduled.yml
@@ -3,6 +3,7 @@ name: Scheduled publish
 on:
   schedule:
     - cron: '20 8 * * 1'
+  workflow_dispatch:
 
 jobs:
   deployment:
@@ -34,13 +35,24 @@ jobs:
       - name: Set nicely formatted current date as env variable
         run: echo "TODAY_FORMATTED=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
-      - name: Build and push weekly image without gcloud
+      - name: Create weekly tag
+        id: tag
+        env:
+          TAG: ${{ steps.latest-tag.outputs.tag }}_${{ env.TODAY }}
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git tag -a $TAG -m "Weekly rebuild of ${{ steps.latest-tag.outputs.tag }}"
+          git push origin $TAG
+          echo "TAG=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Build and push weekly image (w/ aws cli)
         uses: ./.github/workflows/publish
         with:
-          base_image: 'alpine:3.17'
+          bake_target: aws
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          git_tag: ${{ steps.latest-tag.outputs.tag }}
+          git_tag: ${{ steps.tag.outputs.TAG }}
           publish_release: true
           release_title: ${{ steps.latest-tag.outputs.tag }} - weekly release (${{ env.TODAY_FORMATTED }})
           release_body: |
@@ -48,33 +60,33 @@ jobs:
             This is a weekly rebuild of the latest image (`${{ steps.latest-tag.outputs.tag }}`).
             The image is rebuilt to ensure that it is up to date with the latest security patches.
             ## Updated images
-            ### Without gcloud CLI
+            ### Image with aws cli
             - `${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:latest`
-            - `${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:${{ steps.latest-tag.outputs.tag }}_${{ env.TODAY }}`
+            - `${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:${{ steps.tag.outputs.TAG }}`
             - `ghcr.io/spacelift-io/runner-terraform:latest`
-            - `ghcr.io/spacelift-io/runner-terraform:${{ steps.latest-tag.outputs.tag }}_${{ env.TODAY }}`
+            - `ghcr.io/spacelift-io/runner-terraform:${{ steps.tag.outputs.TAG }}`
 
-            ### With gcloud CLI
+            ### Image with gcloud cli
             - `${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-latest`
-            - `${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-${{ steps.latest-tag.outputs.tag }}_${{ env.TODAY }}`
+            - `${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-${{ steps.tag.outputs.TAG }}`
             - `ghcr.io/spacelift-io/runner-terraform:gcp-latest`
-            - `ghcr.io/spacelift-io/runner-terraform:gcp-${{ steps.latest-tag.outputs.tag }}_${{ env.TODAY }}`
-          image_tags: |
-            ${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:latest
-            ${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:${{ steps.latest-tag.outputs.tag }}_${{ env.TODAY }}
-            ghcr.io/spacelift-io/runner-terraform:latest
-            ghcr.io/spacelift-io/runner-terraform:${{ steps.latest-tag.outputs.tag }}_${{ env.TODAY }}
+            - `ghcr.io/spacelift-io/runner-terraform:gcp-${{ steps.tag.outputs.TAG }}`
+          bake_set: |
+            aws.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:latest
+            aws.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:${{ steps.tag.outputs.TAG }}
+            aws.tags=ghcr.io/spacelift-io/runner-terraform:latest
+            aws.tags=ghcr.io/spacelift-io/runner-terraform:${{ steps.tag.outputs.TAG }}
 
-      - name: Build and push weekly image with gcloud
+      - name: Build and push weekly image (w/ gcloud cli)
         uses: ./.github/workflows/publish
         with:
-          base_image: 'gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine'
+          bake_target: gcp
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           git_tag: ${{ steps.latest-tag.outputs.tag }}
           publish_release: false
-          image_tags: |
-            ${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-latest
-            ${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-${{ steps.latest-tag.outputs.tag }}_${{ env.TODAY }}
-            ghcr.io/spacelift-io/runner-terraform:gcp-latest
-            ghcr.io/spacelift-io/runner-terraform:gcp-${{ steps.latest-tag.outputs.tag }}_${{ env.TODAY }}
+          bake_set: |
+            gcp.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-latest
+            gcp.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-${{ steps.tag.outputs.TAG }}
+            gcp.tags=ghcr.io/spacelift-io/runner-terraform:gcp-latest
+            gcp.tags=ghcr.io/spacelift-io/runner-terraform:gcp-${{ steps.tag.outputs.TAG }}

--- a/.github/workflows/publish_tagged.yml
+++ b/.github/workflows/publish_tagged.yml
@@ -28,31 +28,31 @@ jobs:
         with:
           fetch-depth: 0
   
-      - name: Build and push latest image without gcloud
+      - name: Build and push latest image (w/ aws cli)
         uses: ./.github/workflows/publish
         with:
-          base_image: 'alpine:3.17'
+          bake_target: aws
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           git_tag: ${{ steps.latest-tag.outputs.tag }}
           publish_release: true
           release_title: ${{ steps.latest-tag.outputs.tag }}
-          image_tags: |
-            ${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:latest
-            ${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:${{ steps.latest-tag.outputs.tag }}
-            ghcr.io/spacelift-io/runner-terraform:latest
-            ghcr.io/spacelift-io/runner-terraform:${{ steps.latest-tag.outputs.tag }}
+          bake_set: |
+            aws.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:latest
+            aws.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:${{ steps.latest-tag.outputs.tag }}
+            aws.tags=ghcr.io/spacelift-io/runner-terraform:latest
+            aws.tags=ghcr.io/spacelift-io/runner-terraform:${{ steps.latest-tag.outputs.tag }}
 
-      - name: Build and push latest image with gcloud
+      - name: Build and push latest image (w/ gcloud cli)
         uses: ./.github/workflows/publish
         with:
-          base_image: 'gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine'
+          bake_target: gcp
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           git_tag: ${{ steps.latest-tag.outputs.tag }}
           publish_release: false
-          image_tags: |
-            ${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-latest
-            ${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-${{ steps.latest-tag.outputs.tag }}
-            ghcr.io/spacelift-io/runner-terraform:gcp-latest
-            ghcr.io/spacelift-io/runner-terraform:gcp-${{ steps.latest-tag.outputs.tag }}
+          bake_set: |
+            gcp.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-latest
+            gcp.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-${{ steps.latest-tag.outputs.tag }}
+            gcp.tags=ghcr.io/spacelift-io/runner-terraform:gcp-latest
+            gcp.tags=ghcr.io/spacelift-io/runner-terraform:gcp-${{ steps.latest-tag.outputs.tag }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -16,31 +16,36 @@ jobs:
   build:
     strategy:
       matrix:
-        arch: [amd64, arm64]
-        base_image: ["alpine:3.17", "gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine"]
+        target: [aws, gcp]
+        platform: [linux/amd64, linux/arm64]
     name: Analyze
     runs-on: ubuntu-latest
     env:
-      IMAGE_TAG: spacelift:${{ github.sha }}-${{ matrix.arch }}
+      IMAGE_TAG: spacelift-${{ matrix.target }}:${{ github.sha }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@main
 
       - name: Set up QEMU
-        if: matrix.arch == 'arm64'
+        if: matrix.platform == 'linux/arm64'
         uses: docker/setup-qemu-action@v2
         with:
           platforms: linux/arm64
 
-      - name: Build an image from Dockerfile (${{ matrix.base_image }} ${{ matrix.arch }} image)
-        env:
-          PLATFORM: linux/${{ matrix.arch }}
-          DOCKERFILE: ${{ matrix.base_image }}
-        run: |
-          docker build --platform $PLATFORM --pull --build-arg TARGETARCH=${{ matrix.arch }} --build-arg BASE_IMAGE=${{ matrix.base_image }} -t $IMAGE_TAG .
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
-      - name: Run Trivy vulnerability scanner (${{ matrix.base_image }} ${{ matrix.arch }} image)
+      - name: Bake the image
+        uses: docker/bake-action@v2
+        with:
+          targets: ${{ matrix.target }}
+          load: true
+          set: |
+            ${{ matrix.target }}.tags=${{ env.IMAGE_TAG }}
+            ${{ matrix.target }}.platform=${{ matrix.platform }}
+
+      - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: ${{ env.IMAGE_TAG }}
@@ -49,7 +54,7 @@ jobs:
           severity: "CRITICAL,HIGH"
           timeout: "10m"
 
-      - name: Upload Trivy scan results to GitHub Security tab (${{ matrix.base_image }} ${{ matrix.arch }} image)
+      - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: "trivy-results.sarif"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=alpine:3.17
 
-FROM ${BASE_IMAGE}
+FROM ${BASE_IMAGE} AS base
 
 ARG TARGETARCH
 
@@ -16,12 +16,6 @@ RUN apk -U upgrade && apk add --no-cache \
     tzdata
 
 RUN [ -e /usr/bin/python ] || ln -s python3 /usr/bin/python
-RUN if [ -e /google-cloud-sdk/bin/gcloud ]; then \
-    gcloud components install gke-gcloud-auth-plugin; \
-    fi
-
-COPY --from=ghcr.io/spacelift-io/aws-cli-alpine /usr/local/aws-cli/ /usr/local/aws-cli/
-COPY --from=ghcr.io/spacelift-io/aws-cli-alpine /aws-cli-bin/ /usr/local/bin/
 
 # Download infracost
 ADD "https://github.com/infracost/infracost/releases/latest/download/infracost-linux-${TARGETARCH}.tar.gz" /tmp/infracost.tar.gz
@@ -36,5 +30,26 @@ RUN chmod 755 /bin/terragrunt
 
 RUN echo "hosts: files dns" > /etc/nsswitch.conf \
     && adduser --disabled-password --uid=1983 spacelift
+
+FROM base AS aws
+
+COPY --from=ghcr.io/spacelift-io/aws-cli-alpine /usr/local/aws-cli/ /usr/local/aws-cli/
+COPY --from=ghcr.io/spacelift-io/aws-cli-alpine /aws-cli-bin/ /usr/local/bin/
+
+RUN aws --version && \
+    terragrunt --version && \
+    python --version && \
+    infracost --version
+
+USER spacelift
+
+FROM base AS gcp
+
+RUN gcloud components install gke-gcloud-auth-plugin
+
+RUN gcloud --version && \
+    terragrunt --version && \
+    python --version && \
+    infracost --version
 
 USER spacelift

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ with ECR.
 
 ## Images
 
-We publish two images. One has `gcloud` CLI bundled, the other does not.
+We publish two images. The default has `aws` CLI v2 included, the other has `gcloud`.
 This is because `gcloud` is a very large package and we want to keep the image size down.
 
-- `spacelift-io/runner-terraform:latest` -> no `gcloud` CLI
+- `spacelift-io/runner-terraform:latest` -> with `aws` CLI
 - `spacelift-io/runner-terraform:gcp-latest` -> with `gcloud` CLI
 
 ## Branch Model
@@ -28,4 +28,4 @@ $ git tag -a v1.1.0 -m "Release v1.1.0"
 $ git push origin v1.1.0
 ```
 
-Note: we also have a weekly cron job that re-runs the `main` branch just to have the latest package updates.
+We also have a weekly cron job that re-runs the `main` branch just to have the latest package updates.

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,11 @@
+target "aws" {
+    target = "aws"
+    platforms = ["linux/amd64", "linux/arm64"]
+    args = {"BASE_IMAGE": "alpine:3.17"}
+}
+
+target "gcp" {
+    target = "gcp"
+    platforms = ["linux/amd64", "linux/arm64"]
+    args = {"BASE_IMAGE": "gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine"}
+}


### PR DESCRIPTION
The main reason I've made this change is because the GCP flavor of this image currently has a broken AWS CLI installed. 

I'm not sure why is it broken, but we use a different base image for GCP (`gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine` - official Google one) and it doesn't seem to work nicely with AWS CLI. How come we didn't notice it? That's because we don't check if the `aws` cli is executable during our build. 🤦 We only check it during pull request builds...

I've decided that it does not make any sense to keep AWS CLI in the GCP image, so I did a bit of refactoring. We will use different targets in the Dockefile => this means that the **GCP image will not include AWS cli anymore**.

Changes:
- Bumped all GitHub Action versions, one of them gets deprecated in April: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.com/spacelift-io/runner-terraform/pull/38)
- Dockerfile has separate stages for AWS and GCP
- Using buildx bake for building the images
- Our Releases has [stopped in January](https://github.com/spacelift-io/runner-terraform/releases). That's because we're attempting to create releases for the same tag (`v1.2.1`). I've added a mechanism to create a new tag with scheduled releases as well: `<semver>_<current-date>`

Oh and an important change: instead of testing the executables in the `build.yml` workflow, we'll test it during the container building. This makes sure we avoid an issue which just happened: not noticing that the AWS cli is broken.