### PR TITLE
Add separate image with `az` cli

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
   deployment:
     strategy:
       matrix:
-        target: [aws, gcp]
+        target: [aws, gcp, azure]
         platform: [linux/amd64, linux/arm64]
     name: Build the image
     runs-on: ubuntu-latest
@@ -39,3 +39,4 @@ jobs:
           set: |
             ${{ matrix.target }}.tags=runner-terraform:${{ github.sha }}
             ${{ matrix.target }}.platform=${{ matrix.platform }}
+

--- a/.github/workflows/publish_future.yml
+++ b/.github/workflows/publish_future.yml
@@ -46,3 +46,15 @@ jobs:
           bake_set: |
             gcp.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-future
             gcp.tags=ghcr.io/spacelift-io/runner-terraform:gcp-future
+
+      - name: Build and push future image (w/ az cli)
+        uses: ./.github/workflows/publish
+        with:
+          bake_target: azure
+          aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_release: false
+          bake_set: |
+            azure.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-future
+            azure.tags=ghcr.io/spacelift-io/runner-terraform:azure-future
+

--- a/.github/workflows/publish_scheduled.yml
+++ b/.github/workflows/publish_scheduled.yml
@@ -70,6 +70,12 @@ jobs:
             - `${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-${{ steps.tag.outputs.TAG }}`
             - `ghcr.io/spacelift-io/runner-terraform:gcp-latest`
             - `ghcr.io/spacelift-io/runner-terraform:gcp-${{ steps.tag.outputs.TAG }}`
+
+            ### Image with az cli
+            - `${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-latest`
+            - `${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-${{ steps.tag.outputs.TAG }}`
+            - `ghcr.io/spacelift-io/runner-terraform:azure-latest`
+            - `ghcr.io/spacelift-io/runner-terraform:azure-${{ steps.tag.outputs.TAG }}`
           bake_set: |
             aws.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:latest
             aws.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:${{ steps.tag.outputs.TAG }}
@@ -89,3 +95,18 @@ jobs:
             gcp.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-${{ steps.tag.outputs.TAG }}
             gcp.tags=ghcr.io/spacelift-io/runner-terraform:gcp-latest
             gcp.tags=ghcr.io/spacelift-io/runner-terraform:gcp-${{ steps.tag.outputs.TAG }}
+
+      - name: Build and push weekly image (w/ az cli)
+        uses: ./.github/workflows/publish
+        with:
+          bake_target: azure
+          aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          git_tag: ${{ steps.latest-tag.outputs.tag }}
+          publish_release: false
+          bake_set: |
+            azure.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-latest
+            azure.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-${{ steps.tag.outputs.TAG }}
+            azure.tags=ghcr.io/spacelift-io/runner-terraform:azure-latest
+            azure.tags=ghcr.io/spacelift-io/runner-terraform:azure-${{ steps.tag.outputs.TAG }}
+

--- a/.github/workflows/publish_tagged.yml
+++ b/.github/workflows/publish_tagged.yml
@@ -55,3 +55,18 @@ jobs:
             gcp.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-${{ steps.latest-tag.outputs.tag }}
             gcp.tags=ghcr.io/spacelift-io/runner-terraform:gcp-latest
             gcp.tags=ghcr.io/spacelift-io/runner-terraform:gcp-${{ steps.latest-tag.outputs.tag }}
+
+      - name: Build and push latest image (w/ az cli)
+        uses: ./.github/workflows/publish
+        with:
+          bake_target: azure 
+          aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          git_tag: ${{ steps.latest-tag.outputs.tag }}
+          publish_release: false
+          bake_set: |
+            azure.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-latest
+            azure.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-${{ steps.latest-tag.outputs.tag }}
+            azure.tags=ghcr.io/spacelift-io/runner-terraform:azure-latest
+            azure.tags=ghcr.io/spacelift-io/runner-terraform:azure-${{ steps.latest-tag.outputs.tag }}
+

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     strategy:
       matrix:
-        target: [aws, gcp]
+        target: [aws, gcp, azure]
         platform: [linux/amd64, linux/arm64]
     name: Analyze
     runs-on: ubuntu-latest
@@ -58,3 +58,4 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: "trivy-results.sarif"
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,3 +53,13 @@ RUN gcloud --version && \
     infracost --version
 
 USER spacelift
+
+FROM base AS azure
+
+RUN az --version && \
+    terragrunt --version && \
+    python --version && \
+    infracost --version
+
+USER spacelift
+

--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ with ECR.
 
 ## Images
 
-We publish two images. The default has `aws` CLI v2 included, the other has `gcloud`.
-This is because `gcloud` is a very large package and we want to keep the image size down.
+We publish three images. The default has `aws` CLI v2 included, the others
+`gcloud` and `az` respectively.
+This is because `gcloud` and `az` are very large packages and we want to keep the image size down.
 
 - `spacelift-io/runner-terraform:latest` -> with `aws` CLI
 - `spacelift-io/runner-terraform:gcp-latest` -> with `gcloud` CLI
+- `spacelift-io/runner-terraform:azure-latest` -> with `az` CLI
 
 ## Branch Model
 
@@ -29,3 +31,4 @@ $ git push origin v1.1.0
 ```
 
 We also have a weekly cron job that re-runs the `main` branch just to have the latest package updates.
+

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -9,3 +9,10 @@ target "gcp" {
     platforms = ["linux/amd64", "linux/arm64"]
     args = {"BASE_IMAGE": "gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine"}
 }
+
+target "azure" {
+    target = "azure"
+    platforms = ["linux/amd64", "linux/arm64"]
+    args = {"BASE_IMAGE": "mcr.microsoft.com/azure-cli:2.48.1"}
+}
+


### PR DESCRIPTION
This PR adds a `az` cli enabled image based on the latest official `az-cli` docker image published by Microsoft.
[mcr.microsoft.com/azure-cli:2.48.1](https://mcr.microsoft.com/en-us/product/azure-cli/tags)

I tried to just extend your curent build process, more or less copying the gcp related parts.

New lines were added to the files I touched as requested [here](https://github.com/spacelift-io/runner-terraform/pull/31#discussion_r1044300108)
If that's not consistent with the current guidelines I can remove them.