### PR TITLE
Fix `build` job trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,9 @@ name: Build
 
 on:
   push:
-    branches-ignore: [main]
+    tags: [v*]
+  pull_request:
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
Fixing the trigger of CI.

it doesn't fire for contributions. see this: https://github.com/spacelift-io/runner-terraform/pull/42