### PR TITLE
Fix scheduled publish issue (circular dep)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 name: Build
 
 on:
-  push:
-    tags: [v*]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
` ! [remote rejected] v1.3.0_20230508 -> v1.3.0_20230508 (refusing to allow a GitHub App to create or update workflow `.github/workflows/build.yml` without `workflows` permission)`

I mistakenly introduced a dependency where one workflow pushes a tag and it kicks off another workflow. GitHub does not allow that. So lets remove the tag trigger.

https://github.com/spacelift-io/runner-terraform/actions/runs/4913068077