### PR TITLE
Set Azure CLI version to `latest`

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -13,6 +13,6 @@ target "gcp" {
 target "azure" {
     target = "azure"
     platforms = ["linux/amd64", "linux/arm64"]
-    args = {"BASE_IMAGE": "mcr.microsoft.com/azure-cli:2.51.0"}
+    args = {"BASE_IMAGE": "mcr.microsoft.com/azure-cli:latest"}
 }
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -13,6 +13,6 @@ target "gcp" {
 target "azure" {
     target = "azure"
     platforms = ["linux/amd64", "linux/arm64"]
-    args = {"BASE_IMAGE": "mcr.microsoft.com/azure-cli:2.49.0"}
+    args = {"BASE_IMAGE": "mcr.microsoft.com/azure-cli:2.51.0"}
 }
 


### PR DESCRIPTION
Question: should we switch to latest to avoid bumping in the future? I'm fine with `latest`.