### PR TITLE
Add kubectl installation to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,8 @@ FROM base AS gcp
 
 RUN gcloud components install gke-gcloud-auth-plugin
 
+RUN gcloud components install kubectl
+
 RUN gcloud --version && \
     terragrunt --version && \
     python --version && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,10 +45,7 @@ USER spacelift
 
 FROM base AS gcp
 
-RUN gcloud components install gke-gcloud-auth-plugin
-
-RUN gcloud components install kubectl
-
+RUN gcloud components install gke-gcloud-auth-plugin kubectl
 RUN gcloud --version && \
     terragrunt --version && \
     python --version && \


### PR DESCRIPTION
This pull request adds the installation of kubectl to the gcp section of the Dockerfile. The previous execution of `gcloud components install gke-gcloud-auth-plugin` supports kubectl authentication to gke clusters. Having the kubectl cli installed allows users to access their clusters.

Usage of this runner image via spacelift requires a user customize the "Applying" workflow phase by adding the command `gcloud auth login --cred-file=/mnt/workspace/cred-file.json` (or wherever the gcp credentials file is)