### PR TITLE
fix: install only `openssh-client` pkg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk -U upgrade && apk add --no-cache \
     curl \
     git \
     jq \
-    openssh \
+    openssh-client \
     openssh-keygen \
     python3 \
     tzdata


### PR DESCRIPTION
This installs only the SSH client into our images instead of the `openssh` meta package that also bundles the server.
This will reduce the attack surface in case because we don't really need a ssh server in those images.

```
➜ docker run -it alpine:3.20 /bin/sh -c 'apk add openssh-client && apk info'
fetch https://dl-cdn.alpinelinux.org/alpine/v3.20/main/aarch64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.20/community/aarch64/APKINDEX.tar.gz
(1/6) Installing openssh-keygen (9.7_p1-r4)
(2/6) Installing ncurses-terminfo-base (6.4_p20240420-r0)
(3/6) Installing libncursesw (6.4_p20240420-r0)
(4/6) Installing libedit (20240517.3.1-r0)
(5/6) Installing openssh-client-common (9.7_p1-r4)
(6/6) Installing openssh-client-default (9.7_p1-r4)
Executing busybox-1.36.1-r29.trigger
OK: 14 MiB in 20 packages
alpine-baselayout
alpine-baselayout-data
alpine-keys
apk-tools
busybox
busybox-binsh
ca-certificates-bundle
libcrypto3
libedit
libncursesw
libssl3
musl
musl-utils
ncurses-terminfo-base
openssh-client-common
openssh-client-default
openssh-keygen
scanelf
ssl_client
zlib
```