### PR TITLE
ci: add Trivy fallback DB repositories

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -46,13 +46,15 @@ jobs:
             ${{ matrix.target }}.platform=${{ matrix.platform }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.27.0
         with:
           image-ref: ${{ env.IMAGE_TAG }}
           format: "sarif"
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH"
           timeout: "10m"
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -13,6 +13,5 @@ target "gcp" {
 target "azure" {
     target = "azure"
     platforms = ["linux/amd64", "linux/arm64"]
-    args = {"BASE_IMAGE": "mcr.microsoft.com/azure-cli:latest"}
+    args = {"BASE_IMAGE": "mcr.microsoft.com/azure-cli:2.63.0"}
 }
-


### PR DESCRIPTION
Just adding these now to try to avoid people hitting the Trivy rate limiting issues later.