### PR TITLE
ci: use latest Alpine Azure CLI image

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -13,6 +13,5 @@ target "gcp" {
 target "azure" {
     target = "azure"
     platforms = ["linux/amd64", "linux/arm64"]
-    args = {"BASE_IMAGE": "mcr.microsoft.com/azure-cli:latest"}
+    args = {"BASE_IMAGE": "mcr.microsoft.com/azure-cli:2.63.0"}
 }
-


### PR DESCRIPTION
Our Azure CLI versions of the runner image are failing to build currently. It looks like the problem is that Microsoft switched from Alpine to cbl-mariner after v2.63.0. For now I'm pinning to that version since our build process expects Alpine.

The reason I created this PR is because another PR I opened currently has failing checks: https://github.com/spacelift-io/runner-terraform/actions/runs/10769454833/job/29860697729.

I noticed that the [Azure docs](https://learn.microsoft.com/en-us/cli/azure/run-azure-cli-docker) have a warning about the deprecation of the Alpine based image:

<img width="842" alt="image" src="https://github.com/user-attachments/assets/9397f906-a9a6-49c9-b910-fab5a76cd609">
