### PR TITLE
Bump `docker/bake-action` to `v6`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Bake the ${{ matrix.target }} image 
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: ${{ matrix.target }}
           load: true

--- a/.github/workflows/publish/action.yml
+++ b/.github/workflows/publish/action.yml
@@ -59,7 +59,7 @@ runs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push the image
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           push: true
           targets: ${{ inputs.bake_target }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -37,7 +37,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Bake the image
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: ${{ matrix.target }}
           load: true


### PR DESCRIPTION
To fix the build error:

> Error: docker/bake-action < v5 is not compatible with buildx >= 0.20.0, please update your workflow to latest docker/bake-action or use an older buildx version.