### PR TITLE
feat: fips

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,10 @@ jobs:
       - name: Bake the ${{ matrix.target }} image 
         uses: docker/bake-action@v6
         with:
-          targets: ${{ matrix.target }}
+          targets: ${{ matrix.target }},${{ matrix.target }}-fips
           load: true
           set: |
             ${{ matrix.target }}.tags=runner-terraform:${{ github.sha }}
             ${{ matrix.target }}.platform=${{ matrix.platform }}
-
+            ${{ matrix.target }}-fips.tags=runner-terraform:${{ github.sha }}-fips
+            ${{ matrix.target }}-fips.platform=${{ matrix.platform }}

--- a/.github/workflows/publish_future.yml
+++ b/.github/workflows/publish_future.yml
@@ -23,33 +23,39 @@ jobs:
       - name: Build and push future image (w/ aws cli)
         uses: ./.github/workflows/publish
         with:
-          bake_target: aws
+          bake_target: aws,aws-fips
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_release: false
           bake_set: |
             aws.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:future
             aws.tags=ghcr.io/spacelift-io/runner-terraform:future
+            aws-fips.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:future-fips
+            aws-fips.tags=ghcr.io/spacelift-io/runner-terraform:future-fips
 
       - name: Build and push future image (w/ gcloud cli)
         uses: ./.github/workflows/publish
         with:
-          bake_target: gcp
+          bake_target: gcp,gcp-fips
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_release: false
           bake_set: |
             gcp.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-future
             gcp.tags=ghcr.io/spacelift-io/runner-terraform:gcp-future
+            gcp-fips.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-future-fips
+            gcp-fips.tags=ghcr.io/spacelift-io/runner-terraform:gcp-future-fips
 
       - name: Build and push future image (w/ az cli)
         uses: ./.github/workflows/publish
         with:
-          bake_target: azure
+          bake_target: azure,azure-fips
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_release: false
           bake_set: |
             azure.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-future
             azure.tags=ghcr.io/spacelift-io/runner-terraform:azure-future
+            azure-fips.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-future-fips
+            azure-fips.tags=ghcr.io/spacelift-io/runner-terraform:azure-future-fips
 

--- a/.github/workflows/publish_scheduled.yml
+++ b/.github/workflows/publish_scheduled.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Build and push weekly image (w/ aws cli)
         uses: ./.github/workflows/publish
         with:
-          bake_target: aws
+          bake_target: aws,aws-fips
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           git_tag: ${{ steps.tag.outputs.TAG }}
@@ -64,28 +64,47 @@ jobs:
             - `${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:${{ steps.tag.outputs.TAG }}`
             - `ghcr.io/spacelift-io/runner-terraform:latest`
             - `ghcr.io/spacelift-io/runner-terraform:${{ steps.tag.outputs.TAG }}`
+            #### Image with aws cli FIPS
+            - `${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:latest-fips`
+            - `${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:${{ steps.tag.outputs.TAG }}-fips`
+            - `ghcr.io/spacelift-io/runner-terraform:latest-fips`
+            - `ghcr.io/spacelift-io/runner-terraform:${{ steps.tag.outputs.TAG }}-fips`
 
             ### Image with gcloud cli
             - `${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-latest`
             - `${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-${{ steps.tag.outputs.TAG }}`
             - `ghcr.io/spacelift-io/runner-terraform:gcp-latest`
             - `ghcr.io/spacelift-io/runner-terraform:gcp-${{ steps.tag.outputs.TAG }}`
+            #### Image with gcloud cli FIPS
+            - `${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-latest-fips`
+            - `${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-${{ steps.tag.outputs.TAG }}-fips`
+            - `ghcr.io/spacelift-io/runner-terraform:gcp-latest-fips`
+            - `ghcr.io/spacelift-io/runner-terraform:gcp-${{ steps.tag.outputs.TAG }}-fips`
 
             ### Image with az cli
             - `${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-latest`
             - `${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-${{ steps.tag.outputs.TAG }}`
             - `ghcr.io/spacelift-io/runner-terraform:azure-latest`
             - `ghcr.io/spacelift-io/runner-terraform:azure-${{ steps.tag.outputs.TAG }}`
+            #### Image with az cli FIPS
+            - `${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-latest-fips`
+            - `${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-${{ steps.tag.outputs.TAG }}-fips`
+            - `ghcr.io/spacelift-io/runner-terraform:azure-latest-fips`
+            - `ghcr.io/spacelift-io/runner-terraform:azure-${{ steps.tag.outputs.TAG }}-fips`
           bake_set: |
             aws.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:latest
             aws.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:${{ steps.tag.outputs.TAG }}
             aws.tags=ghcr.io/spacelift-io/runner-terraform:latest
             aws.tags=ghcr.io/spacelift-io/runner-terraform:${{ steps.tag.outputs.TAG }}
+            aws-fips.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:latest-fips
+            aws-fips.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:${{ steps.tag.outputs.TAG }}-fips
+            aws-fips.tags=ghcr.io/spacelift-io/runner-terraform:latest-fips
+            aws-fips.tags=ghcr.io/spacelift-io/runner-terraform:${{ steps.tag.outputs.TAG }}-fips
 
       - name: Build and push weekly image (w/ gcloud cli)
         uses: ./.github/workflows/publish
         with:
-          bake_target: gcp
+          bake_target: gcp,gcp-fips
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           git_tag: ${{ steps.latest-tag.outputs.tag }}
@@ -95,11 +114,15 @@ jobs:
             gcp.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-${{ steps.tag.outputs.TAG }}
             gcp.tags=ghcr.io/spacelift-io/runner-terraform:gcp-latest
             gcp.tags=ghcr.io/spacelift-io/runner-terraform:gcp-${{ steps.tag.outputs.TAG }}
+            gcp-fips.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-latest-fips
+            gcp-fips.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-${{ steps.tag.outputs.TAG }}-fips
+            gcp-fips.tags=ghcr.io/spacelift-io/runner-terraform:gcp-latest-fips
+            gcp-fips.tags=ghcr.io/spacelift-io/runner-terraform:gcp-${{ steps.tag.outputs.TAG }}-fips
 
       - name: Build and push weekly image (w/ az cli)
         uses: ./.github/workflows/publish
         with:
-          bake_target: azure
+          bake_target: azure,azure-fips
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           git_tag: ${{ steps.latest-tag.outputs.tag }}
@@ -109,4 +132,7 @@ jobs:
             azure.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-${{ steps.tag.outputs.TAG }}
             azure.tags=ghcr.io/spacelift-io/runner-terraform:azure-latest
             azure.tags=ghcr.io/spacelift-io/runner-terraform:azure-${{ steps.tag.outputs.TAG }}
-
+            azure-fips.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-latest-fips
+            azure-fips.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-${{ steps.tag.outputs.TAG }}-fips
+            azure-fips.tags=ghcr.io/spacelift-io/runner-terraform:azure-latest-fips
+            azure-fips.tags=ghcr.io/spacelift-io/runner-terraform:azure-${{ steps.tag.outputs.TAG }}-fips

--- a/.github/workflows/publish_tagged.yml
+++ b/.github/workflows/publish_tagged.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build and push latest image (w/ aws cli)
         uses: ./.github/workflows/publish
         with:
-          bake_target: aws
+          bake_target: aws,aws-fips
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           git_tag: ${{ steps.latest-tag.outputs.tag }}
@@ -41,11 +41,15 @@ jobs:
             aws.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:${{ steps.latest-tag.outputs.tag }}
             aws.tags=ghcr.io/spacelift-io/runner-terraform:latest
             aws.tags=ghcr.io/spacelift-io/runner-terraform:${{ steps.latest-tag.outputs.tag }}
+            aws-fips.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:latest-fips
+            aws-fips.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:${{ steps.latest-tag.outputs.tag }}-fips
+            aws-fips.tags=ghcr.io/spacelift-io/runner-terraform:latest-fips
+            aws-fips.tags=ghcr.io/spacelift-io/runner-terraform:${{ steps.latest-tag.outputs.tag }}-fips
 
       - name: Build and push latest image (w/ gcloud cli)
         uses: ./.github/workflows/publish
         with:
-          bake_target: gcp
+          bake_target: gcp,gcp-fips
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           git_tag: ${{ steps.latest-tag.outputs.tag }}
@@ -55,11 +59,15 @@ jobs:
             gcp.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-${{ steps.latest-tag.outputs.tag }}
             gcp.tags=ghcr.io/spacelift-io/runner-terraform:gcp-latest
             gcp.tags=ghcr.io/spacelift-io/runner-terraform:gcp-${{ steps.latest-tag.outputs.tag }}
+            gcp-fips.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-latest-fips
+            gcp-fips.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-${{ steps.latest-tag.outputs.tag }}-fips
+            gcp-fips.tags=ghcr.io/spacelift-io/runner-terraform:gcp-latest-fips
+            gcp-fips.tags=ghcr.io/spacelift-io/runner-terraform:gcp-${{ steps.latest-tag.outputs.tag }}-fips
 
       - name: Build and push latest image (w/ az cli)
         uses: ./.github/workflows/publish
         with:
-          bake_target: azure 
+          bake_target: azure,azure-fips
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           git_tag: ${{ steps.latest-tag.outputs.tag }}
@@ -69,4 +77,7 @@ jobs:
             azure.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-${{ steps.latest-tag.outputs.tag }}
             azure.tags=ghcr.io/spacelift-io/runner-terraform:azure-latest
             azure.tags=ghcr.io/spacelift-io/runner-terraform:azure-${{ steps.latest-tag.outputs.tag }}
-
+            azure-fips.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-latest-fips
+            azure-fips.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-${{ steps.latest-tag.outputs.tag }}-fips
+            azure-fips.tags=ghcr.io/spacelift-io/runner-terraform:azure-latest-fips
+            azure-fips.tags=ghcr.io/spacelift-io/runner-terraform:azure-${{ steps.latest-tag.outputs.tag }}-fips

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -39,11 +39,13 @@ jobs:
       - name: Bake the image
         uses: docker/bake-action@v6
         with:
-          targets: ${{ matrix.target }}
+          targets: ${{ matrix.target }},${{ matrix.target }}-fips
           load: true
           set: |
             ${{ matrix.target }}.tags=${{ env.IMAGE_TAG }}
             ${{ matrix.target }}.platform=${{ matrix.platform }}
+            ${{ matrix.target }}-fips.tags=${{ env.IMAGE_TAG }}-fips
+            ${{ matrix.target }}-fips.platform=${{ matrix.platform }}
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.27.0
@@ -56,8 +58,25 @@ jobs:
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
 
+      - name: Run Trivy vulnerability scanner FIPS Images
+        uses: aquasecurity/trivy-action@0.27.0
+        with:
+          image-ref: ${{ env.IMAGE_TAG }}-fips
+          format: "sarif"
+          output: "trivy-results-fips.sarif"
+          severity: "CRITICAL,HIGH"
+          timeout: "10m"
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: "trivy-results.sarif"
+          category: "${{ matrix.target }}-${{ matrix.platform }}"
 
+      - name: Upload Trivy scan results to GitHub Security tab FIPS Images
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: "trivy-results-fips.sarif"
+          category: "${{ matrix.target }}-${{ matrix.platform }}-fips"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ This is because `gcloud` and `az` are very large packages and we want to keep th
 - `spacelift-io/runner-terraform:gcp-latest` -> with `gcloud` CLI
 - `spacelift-io/runner-terraform:azure-latest` -> with `az` CLI
 
+### FIPS
+
+All the tags have a `-fips` variant that has been installed with the latest FIPS compliant OpenSSL (3.1.2 at the time of writing).
+You are still responsible to run these images on a FIPS hardened host ensuring youre only communicating with FIPS enabled endpoints.
+
+- `spacelift-io/runner-terraform:latest-fips` -> with `aws` CLI & FIPS OpenSSL
+- `spacelift-io/runner-terraform:gcp-latest-fips` -> with `gcloud` CLI & FIPS OpenSSL
+- `spacelift-io/runner-terraform:azure-latest-fips` -> with `az` CLI & FIPS OpenSSL
+
 ## Branch Model
 
 All changes merged to `main` branch are automatically built and pushed to the Docker repository with the `future` tag.

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -15,3 +15,27 @@ target "azure" {
     platforms = ["linux/amd64", "linux/arm64"]
     args = {"BASE_IMAGE": "alpine:3.21"}
 }
+
+target "aws-fips" {
+    target = "aws"
+    platforms = ["linux/amd64", "linux/arm64"]
+    args = {
+        "BASE_IMAGE": "ghcr.io/spacelift-io/alpine-fips:base-latest"
+    }
+}
+
+target "gcp-fips" {
+    target = "gcp"
+    platforms = ["linux/amd64", "linux/arm64"]
+    args = {
+        "BASE_IMAGE": "ghcr.io/spacelift-io/alpine-fips:gcp-latest"
+    }
+}
+
+target "azure-fips" {
+    target = "azure"
+    platforms = ["linux/amd64", "linux/arm64"]
+    args = {
+        "BASE_IMAGE": "ghcr.io/spacelift-io/alpine-fips:base-latest"
+    }
+}


### PR DESCRIPTION
Enables a FIPS version of the image.

All tags that are built for our normal images will have a `-fips` version built as well. So `latest-fips`, `gcp-latest-fips`, etc.

These images MUST be ran on a FIPS enabled host to take advantage of the compliance.

### Proof
First command shows that the image is running on a fips enabled host, second command runs the docker image built with the same commands showing its also fips enabled.
![Screenshot 2025-03-12 at 9 19 51 AM](https://github.com/user-attachments/assets/3f7a7ec7-f231-4c59-b6da-e1a37be94649)

The image also runs as expected in spacelift
![Screenshot 2025-03-12 at 9 51 31 AM](https://github.com/user-attachments/assets/d963bb75-9e2a-4b59-895a-13a26f9feda7)
