### PR TITLE
Attempt to fix `no space left on device` build issue

### DIFF
--- a/.github/workflows/publish/action.yml
+++ b/.github/workflows/publish/action.yml
@@ -57,6 +57,10 @@ runs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      
+      - name: Clean up space
+        shell: bash
+        run: docker system prune -af 
 
       - name: Build and push the image
         uses: docker/bake-action@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,12 +56,12 @@ USER spacelift
 
 FROM base AS azure-build
 
-RUN apk add --no-cache py3-pip gcc musl-dev python3-dev libffi-dev openssl-dev cargo make
-
-RUN python3 -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-RUN pip install --no-cache-dir azure-cli
+RUN apk add --virtual=build --no-cache py3-pip gcc musl-dev python3-dev libffi-dev openssl-dev cargo make && \
+    python3 -m venv /opt/venv && \
+    pip install --no-cache-dir azure-cli && \
+    apk del --purge build
 
 FROM base AS azure
 


### PR DESCRIPTION
This is an attempt to fix the build issue where the azure build runs out of space:

> ERROR: target azure: failed to solve: ResourceExhausted: mount callback failed [...] no space left on device

The last 2 failed:
https://github.com/spacelift-io/runner-terraform/actions/workflows/publish_scheduled.yml
https://github.com/spacelift-io/runner-terraform/actions/runs/14570242386/job/40866063192

This solution is based off:
- https://stackoverflow.com/a/46222036: virtual apk packages that are easy to drop afterwards
- a bit of LLM help: simply running a Docker prune between steps should clean up some space for upcoming Docker builds
