### PR TITLE
Bump Alpine to 3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=alpine:3.21
+ARG BASE_IMAGE=alpine:3.22
 
 FROM ${BASE_IMAGE} AS base
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,7 +1,7 @@
 target "aws" {
     target = "aws"
     platforms = ["linux/amd64", "linux/arm64"]
-    args = {"BASE_IMAGE": "alpine:3.21"}
+    args = {"BASE_IMAGE": "alpine:3.22"}
 }
 
 target "gcp" {
@@ -13,7 +13,7 @@ target "gcp" {
 target "azure" {
     target = "azure"
     platforms = ["linux/amd64", "linux/arm64"]
-    args = {"BASE_IMAGE": "alpine:3.21"}
+    args = {"BASE_IMAGE": "alpine:3.22"}
 }
 
 target "aws-fips" {


### PR DESCRIPTION
It was released 3 months ago and now we're already at 3.22.1: https://www.alpinelinux.org/posts/Alpine-3.19.8-3.20.7-3.21.4-3.22.1-released.html