### PR TITLE
fix: make sure we checkout the correct tag

### DIFF
--- a/.github/workflows/publish_tagged.yml
+++ b/.github/workflows/publish_tagged.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Checkout repository code
         uses: actions/checkout@main
         with:
+          ref: ${{ steps.latest-tag.outputs.tag }}
           fetch-depth: 0
   
       - name: Build and push latest image (w/ aws cli)


### PR DESCRIPTION
The weekly release process causes us to release main exactly 1 week after main changes, even if the code hasnt been tagged yet.

1. The publish_scheduled workflow calls the publish workflow with a new tag in the first week: https://github.com/spacelift-io/runner-terraform/blob/main/.github/workflows/publish_scheduled.yml#L54
2. The publish workflow creates a new tag that begins with a v: https://github.com/spacelift-io/runner-terraform/blob/main/.github/workflows/publish/action.yml#L72
3. This triggers the publish tag workflow, which currently does NOT checkout the tag. Instead it will checkout the head of main: https://github.com/spacelift-io/runner-terraform/blob/main/.github/workflows/publish_tagged.yml#L6
4. It then releases the head of main