### PR TITLE
fix: only publish release after all image builds succeed

### DIFF
--- a/.github/workflows/publish/action.yml
+++ b/.github/workflows/publish/action.yml
@@ -11,22 +11,9 @@ inputs:
   github_token:
     description: The GitHub token. Used to authenticate with GitHub registry.
     required: true
-  git_tag:
-    description: Git tag to use for the GitHub Release
-    required: false
   bake_set:
     description: The `set` argument of the bake action
     required: true
-  publish_release:
-    description: Whether to publish a GitHub Release
-    required: true
-    default: false
-  release_title:
-    description: The title of the GitHub Release.
-    required: false
-  release_body:
-    description: The body of the GitHub Release. If not provided, the body will be auto-generated.
-    required: false
 
 runs:
   using: composite
@@ -68,13 +55,3 @@ runs:
           push: true
           targets: ${{ inputs.bake_target }}
           set: ${{ inputs.bake_set }}
-
-      - name: Create release
-        uses: ncipollo/release-action@v1
-        if: inputs.publish_release == 'true'
-        with:
-          name: ${{ inputs.release_title }}
-          tag: ${{ inputs.git_tag }}
-          body: ${{ inputs.release_body }}
-          generateReleaseNotes: true
-          allowUpdates: true

--- a/.github/workflows/publish_future.yml
+++ b/.github/workflows/publish_future.yml
@@ -26,7 +26,6 @@ jobs:
           bake_target: aws,aws-fips
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_release: false
           bake_set: |
             aws.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:future
             aws.tags=ghcr.io/spacelift-io/runner-terraform:future
@@ -53,7 +52,6 @@ jobs:
           bake_target: gcp,gcp-fips
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_release: false
           bake_set: |
             gcp.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-future
             gcp.tags=ghcr.io/spacelift-io/runner-terraform:gcp-future
@@ -80,7 +78,6 @@ jobs:
           bake_target: azure,azure-fips
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_release: false
           bake_set: |
             azure.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-future
             azure.tags=ghcr.io/spacelift-io/runner-terraform:azure-future

--- a/.github/workflows/publish_scheduled.yml
+++ b/.github/workflows/publish_scheduled.yml
@@ -69,10 +69,94 @@ jobs:
           bake_target: aws,aws-fips
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          git_tag: ${{ needs.create-tag.outputs.weekly_tag }}
-          publish_release: true
-          release_title: ${{ needs.create-tag.outputs.latest_tag }} - weekly release (${{ needs.create-tag.outputs.today_formatted }})
-          release_body: |
+          bake_set: |
+            aws.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:latest
+            aws.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:${{ needs.create-tag.outputs.weekly_tag }}
+            aws.tags=ghcr.io/spacelift-io/runner-terraform:latest
+            aws.tags=ghcr.io/spacelift-io/runner-terraform:${{ needs.create-tag.outputs.weekly_tag }}
+            aws-fips.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:latest-fips
+            aws-fips.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:${{ needs.create-tag.outputs.weekly_tag }}-fips
+            aws-fips.tags=ghcr.io/spacelift-io/runner-terraform:latest-fips
+            aws-fips.tags=ghcr.io/spacelift-io/runner-terraform:${{ needs.create-tag.outputs.weekly_tag }}-fips
+
+  build-gcp:
+    name: Build and push weekly image (w/ gcloud cli)
+    runs-on: ubuntu-latest
+    needs: create-tag
+    permissions:
+      id-token: write
+      contents: write
+      packages: write
+
+    steps:
+      - name: Checkout repository code
+        uses: actions/checkout@main
+        with:
+          ref: ${{ needs.create-tag.outputs.latest_tag }}
+          fetch-depth: 0
+
+      - name: Build and push weekly image (w/ gcloud cli)
+        uses: ./.github/workflows/publish
+        with:
+          bake_target: gcp,gcp-fips
+          aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          bake_set: |
+            gcp.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-latest
+            gcp.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-${{ needs.create-tag.outputs.weekly_tag }}
+            gcp.tags=ghcr.io/spacelift-io/runner-terraform:gcp-latest
+            gcp.tags=ghcr.io/spacelift-io/runner-terraform:gcp-${{ needs.create-tag.outputs.weekly_tag }}
+            gcp-fips.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-latest-fips
+            gcp-fips.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-${{ needs.create-tag.outputs.weekly_tag }}-fips
+            gcp-fips.tags=ghcr.io/spacelift-io/runner-terraform:gcp-latest-fips
+            gcp-fips.tags=ghcr.io/spacelift-io/runner-terraform:gcp-${{ needs.create-tag.outputs.weekly_tag }}-fips
+
+  build-azure:
+    name: Build and push weekly image (w/ az cli)
+    runs-on: ubuntu-latest
+    needs: create-tag
+    permissions:
+      id-token: write
+      contents: write
+      packages: write
+
+    steps:
+      - name: Checkout repository code
+        uses: actions/checkout@main
+        with:
+          ref: ${{ needs.create-tag.outputs.latest_tag }}
+          fetch-depth: 0
+
+      - name: Build and push weekly image (w/ az cli)
+        uses: ./.github/workflows/publish
+        with:
+          bake_target: azure,azure-fips
+          aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          bake_set: |
+            azure.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-latest
+            azure.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-${{ needs.create-tag.outputs.weekly_tag }}
+            azure.tags=ghcr.io/spacelift-io/runner-terraform:azure-latest
+            azure.tags=ghcr.io/spacelift-io/runner-terraform:azure-${{ needs.create-tag.outputs.weekly_tag }}
+            azure-fips.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-latest-fips
+            azure-fips.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-${{ needs.create-tag.outputs.weekly_tag }}-fips
+            azure-fips.tags=ghcr.io/spacelift-io/runner-terraform:azure-latest-fips
+            azure-fips.tags=ghcr.io/spacelift-io/runner-terraform:azure-${{ needs.create-tag.outputs.weekly_tag }}-fips
+
+  create-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [create-tag, build-aws, build-gcp, build-azure]
+    permissions:
+      contents: write
+
+    steps:
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          name: ${{ needs.create-tag.outputs.latest_tag }} - weekly release (${{ needs.create-tag.outputs.today_formatted }})
+          tag: ${{ needs.create-tag.outputs.weekly_tag }}
+          body: |
             ## Weekly rebuild
             This is a weekly rebuild of the latest image (`${{ needs.create-tag.outputs.latest_tag }}`).
             The image is rebuilt to ensure that it is up to date with the latest security patches.
@@ -109,80 +193,5 @@ jobs:
             - `${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-${{ needs.create-tag.outputs.weekly_tag }}-fips`
             - `ghcr.io/spacelift-io/runner-terraform:azure-latest-fips`
             - `ghcr.io/spacelift-io/runner-terraform:azure-${{ needs.create-tag.outputs.weekly_tag }}-fips`
-          bake_set: |
-            aws.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:latest
-            aws.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:${{ needs.create-tag.outputs.weekly_tag }}
-            aws.tags=ghcr.io/spacelift-io/runner-terraform:latest
-            aws.tags=ghcr.io/spacelift-io/runner-terraform:${{ needs.create-tag.outputs.weekly_tag }}
-            aws-fips.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:latest-fips
-            aws-fips.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:${{ needs.create-tag.outputs.weekly_tag }}-fips
-            aws-fips.tags=ghcr.io/spacelift-io/runner-terraform:latest-fips
-            aws-fips.tags=ghcr.io/spacelift-io/runner-terraform:${{ needs.create-tag.outputs.weekly_tag }}-fips
-
-  build-gcp:
-    name: Build and push weekly image (w/ gcloud cli)
-    runs-on: ubuntu-latest
-    needs: create-tag
-    permissions:
-      id-token: write
-      contents: write
-      packages: write
-
-    steps:
-      - name: Checkout repository code
-        uses: actions/checkout@main
-        with:
-          ref: ${{ needs.create-tag.outputs.latest_tag }}
-          fetch-depth: 0
-
-      - name: Build and push weekly image (w/ gcloud cli)
-        uses: ./.github/workflows/publish
-        with:
-          bake_target: gcp,gcp-fips
-          aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          git_tag: ${{ needs.create-tag.outputs.latest_tag }}
-          publish_release: false
-          bake_set: |
-            gcp.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-latest
-            gcp.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-${{ needs.create-tag.outputs.weekly_tag }}
-            gcp.tags=ghcr.io/spacelift-io/runner-terraform:gcp-latest
-            gcp.tags=ghcr.io/spacelift-io/runner-terraform:gcp-${{ needs.create-tag.outputs.weekly_tag }}
-            gcp-fips.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-latest-fips
-            gcp-fips.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-${{ needs.create-tag.outputs.weekly_tag }}-fips
-            gcp-fips.tags=ghcr.io/spacelift-io/runner-terraform:gcp-latest-fips
-            gcp-fips.tags=ghcr.io/spacelift-io/runner-terraform:gcp-${{ needs.create-tag.outputs.weekly_tag }}-fips
-
-  build-azure:
-    name: Build and push weekly image (w/ az cli)
-    runs-on: ubuntu-latest
-    needs: create-tag
-    permissions:
-      id-token: write
-      contents: write
-      packages: write
-
-    steps:
-      - name: Checkout repository code
-        uses: actions/checkout@main
-        with:
-          ref: ${{ needs.create-tag.outputs.latest_tag }}
-          fetch-depth: 0
-
-      - name: Build and push weekly image (w/ az cli)
-        uses: ./.github/workflows/publish
-        with:
-          bake_target: azure,azure-fips
-          aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          git_tag: ${{ needs.create-tag.outputs.latest_tag }}
-          publish_release: false
-          bake_set: |
-            azure.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-latest
-            azure.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-${{ needs.create-tag.outputs.weekly_tag }}
-            azure.tags=ghcr.io/spacelift-io/runner-terraform:azure-latest
-            azure.tags=ghcr.io/spacelift-io/runner-terraform:azure-${{ needs.create-tag.outputs.weekly_tag }}
-            azure-fips.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-latest-fips
-            azure-fips.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-${{ needs.create-tag.outputs.weekly_tag }}-fips
-            azure-fips.tags=ghcr.io/spacelift-io/runner-terraform:azure-latest-fips
-            azure-fips.tags=ghcr.io/spacelift-io/runner-terraform:azure-${{ needs.create-tag.outputs.weekly_tag }}-fips
+          generateReleaseNotes: true
+          allowUpdates: true

--- a/.github/workflows/publish_tagged.yml
+++ b/.github/workflows/publish_tagged.yml
@@ -44,9 +44,6 @@ jobs:
           bake_target: aws,aws-fips
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          git_tag: ${{ needs.get-tag.outputs.latest_tag }}
-          publish_release: true
-          release_title: ${{ needs.get-tag.outputs.latest_tag }}
           bake_set: |
             aws.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:latest
             aws.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:${{ needs.get-tag.outputs.latest_tag }}
@@ -79,8 +76,6 @@ jobs:
           bake_target: gcp,gcp-fips
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          git_tag: ${{ needs.get-tag.outputs.latest_tag }}
-          publish_release: false
           bake_set: |
             gcp.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-latest
             gcp.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:gcp-${{ needs.get-tag.outputs.latest_tag }}
@@ -113,8 +108,6 @@ jobs:
           bake_target: azure,azure-fips
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          git_tag: ${{ needs.get-tag.outputs.latest_tag }}
-          publish_release: false
           bake_set: |
             azure.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-latest
             azure.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-${{ needs.get-tag.outputs.latest_tag }}
@@ -124,3 +117,19 @@ jobs:
             azure-fips.tags=${{ secrets.PUBLIC_RUNNER_TERRAFORM_ECR_REPOSITORY_URL }}:azure-${{ needs.get-tag.outputs.latest_tag }}-fips
             azure-fips.tags=ghcr.io/spacelift-io/runner-terraform:azure-latest-fips
             azure-fips.tags=ghcr.io/spacelift-io/runner-terraform:azure-${{ needs.get-tag.outputs.latest_tag }}-fips
+
+  create-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [get-tag, build-aws, build-gcp, build-azure]
+    permissions:
+      contents: write
+
+    steps:
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          name: ${{ needs.get-tag.outputs.latest_tag }}
+          tag: ${{ needs.get-tag.outputs.latest_tag }}
+          generateReleaseNotes: true
+          allowUpdates: true


### PR DESCRIPTION
While splitting the image publishing out into separate jobs for AWS, Azure and GCP, I noticed that we publish the new release as part of the AWS publish, not when all the image publishes have completed.

I've adjusted the workflows so that we do the release creation as a separate job that relies on all three images to successfully publish before creating the new release.