### PR TITLE
feat: bump base image to alpine 3.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=alpine:3.23
+ARG BASE_IMAGE=alpine:3.24
 
 FROM ${BASE_IMAGE} AS base
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,7 +1,7 @@
 target "aws" {
     target = "aws"
     platforms = ["linux/amd64", "linux/arm64"]
-    args = {"BASE_IMAGE": "alpine:3.23"}
+    args = {"BASE_IMAGE": "alpine:3.24"}
 }
 
 target "gcp" {
@@ -13,7 +13,7 @@ target "gcp" {
 target "azure" {
     target = "azure"
     platforms = ["linux/amd64", "linux/arm64"]
-    args = {"BASE_IMAGE": "alpine:3.23"}
+    args = {"BASE_IMAGE": "alpine:3.24"}
 }
 
 target "aws-fips" {


### PR DESCRIPTION
This also ensures that python is bumped to the latest 3.14 at the time of authoring this PR.