### PR TITLE
fix: correct typos in Dockerfile comment and README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apk -U upgrade && apk add --no-cache \
     py3-pip \
     tzdata
 
-# Breaking system packages should be fine sice tofu does not use python
+# Breaking system packages should be fine since tofu does not use python
 RUN python3 -m pip install spaceforge --break-system-packages
 
 # Download infracost

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This is because `gcloud` and `az` are very large packages and we want to keep th
 ### FIPS
 
 All the tags have a `-fips` variant that has been installed with the latest FIPS compliant OpenSSL (3.1.2 at the time of writing).
-You are still responsible to run these images on a FIPS hardened host ensuring youre only communicating with FIPS enabled endpoints.
+You are still responsible to run these images on a FIPS hardened host ensuring you're only communicating with FIPS enabled endpoints.
 
 - `spacelift-io/runner-terraform:latest-fips` -> with `aws` CLI & FIPS OpenSSL
 - `spacelift-io/runner-terraform:gcp-latest-fips` -> with `gcloud` CLI & FIPS OpenSSL


### PR DESCRIPTION
## What

Fixes two typos:

- `Dockerfile`: `sice` → `since`
- `README.md`: `youre` → `you're`

## Why

Minor documentation/comment corrections.